### PR TITLE
Tiny little fixes

### DIFF
--- a/assets/css/_global.sss
+++ b/assets/css/_global.sss
@@ -4,6 +4,6 @@
 
 body
   color: var(--black)
-  padding: 50px
   font-family: Roboto, -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif
   font-weight: 300
+  padding: 10px

--- a/assets/css/_global.sss
+++ b/assets/css/_global.sss
@@ -1,5 +1,6 @@
 :root
   --black: #333
+  --gray: #ddd
 
 body
   color: var(--black)

--- a/assets/css/_global.sss
+++ b/assets/css/_global.sss
@@ -6,5 +6,4 @@ body
   color: var(--black)
   padding: 50px
   font-family: Roboto, -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif
-  font-weight: 100
-  -webkit-font-smoothing: antialiased
+  font-weight: 300

--- a/assets/css/index.sss
+++ b/assets/css/index.sss
@@ -13,6 +13,9 @@ main
 h1
   margin: 0
   font-weight: 100
+  font-weight: 300
+  -webkit-font-smoothing: antialiased
+  text-align: center
 
 .social
   display: flex
@@ -94,6 +97,7 @@ table
     color: white
     border: 1px solid #464646
     font-weight: 500
+    -webkit-font-smoothing: antialiased
 
   & td:not(.author):not(.quality)
     text-align: left
@@ -105,6 +109,8 @@ table
     padding-bottom: 1px
     border-bottom: 1px solid transparent
     transition: all .25s ease
+    -webkit-font-smoothing: antialiased
+
 
     &:hover
       border-bottom-color: var(--black)

--- a/assets/css/index.sss
+++ b/assets/css/index.sss
@@ -7,12 +7,15 @@ main
   display: flex
   flex-direction: column
   align-items: center
-  max-width: 850px
   margin: 0 auto
+  max-width: 600px
+  @media screen and (min-width: 750px)
+    max-width: 700px
+  @media screen and (min-width: 920px)
+    max-width: 850px
 
 h1
-  margin: 0
-  font-weight: 100
+  margin: 50px 0 0
   font-weight: 300
   -webkit-font-smoothing: antialiased
   text-align: center
@@ -61,9 +64,11 @@ h1
 
   & .field
     width: 100%
+    margin: 0
     padding: 10px
     font-size: 1.1em
     border: 1px solid #ccc
+    border-radius: 4px 0 0 4px
 
     &:focus
       outline: 0
@@ -71,14 +76,47 @@ h1
   & input[type=submit]
     text-indent: -9999px
     width: 50px
-    height: 45px
+    height: 44px
     border: 1px solid #ccc
     border-left: none
+    border-radius: 0 4px 4px 0
     background: white url('../img/search.svg') center center no-repeat
     cursor: pointer
 
     &:focus
       outline: 0
+
+.table-wrapper-fx
+  width: 100%
+  position: relative
+
+  &:before, &:after
+    content: " "
+    display: block
+    width: 10px
+    position: absolute
+    z-index: 2
+    top: 0
+    bottom: 0
+    background: red
+    opacity: 0
+    transition: opacity .15s
+
+  &:before
+    background: linear-gradient(to left, rgba(0,0,0,.01), rgba(0,0,0,.2))
+    left: 0
+  &.is-scrolled-left:before
+    opacity: 1
+
+  &:after
+    background: linear-gradient(to right, rgba(0,0,0,.01), rgba(0,0,0,.2))
+    right: 0
+  &.is-scrolled-right:after
+    opacity: 1
+
+.table-wrapper
+  width: 100%
+  overflow: scroll
 
 table
   width: 100%
@@ -110,7 +148,6 @@ table
     border-bottom: 1px solid transparent
     transition: all .25s ease
     -webkit-font-smoothing: antialiased
-
 
     &:hover
       border-bottom-color: var(--black)
@@ -146,7 +183,7 @@ table
       background-color: var(--gray)
 
 small
-  margin-top: 30px
+  margin: 30px 0 50px
   opacity: 0.5
 
   & a

--- a/assets/css/index.sss
+++ b/assets/css/index.sss
@@ -113,7 +113,7 @@ table
     display: flex
     justify-content: center
 
-    & a
+    & a, & span
       display: block
       background-color: var(--black)
       background-position: center center
@@ -135,6 +135,9 @@ table
 
       &:last-child
         margin-right: 0
+
+    & span
+      background-color: var(--gray)
 
 small
   margin-top: 30px

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -36,3 +36,33 @@ $('.search').onkeyup = () => {
     toHide.forEach((el) => { el.className = `${el.className} hidden` })
   }
 }
+
+let isTableScrolling = false
+const tableWrapper = $('.table-wrapper')
+const tableWrapperFx = $('.table-wrapper-fx')
+const tableWrapperLeft = $('.tableWrapper:before')
+const tableWrapperright = $('.tableWrapper:after')
+
+tableWrapper.onscroll = () => {
+  isTableScrolling = true
+}
+const setTableScrollFx = () => {
+  if (tableWrapper.scrollLeft > 0) {
+    tableWrapperFx.classList.add('is-scrolled-left')
+  } else {
+    tableWrapperFx.classList.remove('is-scrolled-left')
+  }
+  if (tableWrapper.scrollWidth - tableWrapper.clientWidth - tableWrapper.scrollLeft > 0) {
+    tableWrapperFx.classList.add('is-scrolled-right')
+  } else {
+    tableWrapperFx.classList.remove('is-scrolled-right')
+  }
+}
+
+setInterval(() => {
+  if (isTableScrolling) {
+    setTableScrollFx()
+    isTableScrolling = false
+  }
+}, 100)
+setTableScrollFx()

--- a/views/index.sgr
+++ b/views/index.sgr
@@ -31,8 +31,14 @@ extends(src='layout.sgr')
             a(href='https://npmjs.com/~{{ p.package.publisher.username }}') {{ p.package.publisher.username }}
           td
             .links
-              a.github(href='{{ p.package.links.repository }}') gh
-              a.npm(href='{{ p.package.links.npm }}') npm
+              if(condition='p.package.links.repository')
+                a.github(href='{{ p.package.links.repository }}') gh
+              else
+                span.github gh
+              if(condition='p.package.links.npm')
+                a.npm(href='{{ p.package.links.npm }}') npm
+              else
+                span.npm npm
 
     small(mdi) built with [spike](https://spike.cf)
 

--- a/views/index.sgr
+++ b/views/index.sgr
@@ -24,7 +24,7 @@ extends(src='layout.sgr')
       each(loop='p, i of plugins')
         tr(class='p{{ i }}')
           td.name
-            a(href='{{ p.package.links.repository }}') {{ p.package.name }}
+            a(href='{{ p.package.links.repository || p.package.links.npm }}') {{ p.package.name }}
           td {{ p.package.description }}
           td.quality {{ Math.round(((p.score.detail.quality + p.score.detail.maintenance) / 2) * 100) }}
           td.author

--- a/views/index.sgr
+++ b/views/index.sgr
@@ -14,31 +14,33 @@ extends(src='layout.sgr')
       input.field(placeholder='search...')
       input(type='submit')
 
-    table
-      tr.header
-        th Name
-        th Description
-        th Quality
-        th Author
-        th Links
-      each(loop='p, i of plugins')
-        tr(class='p{{ i }}')
-          td.name
-            a(href='{{ p.package.links.repository || p.package.links.npm }}') {{ p.package.name }}
-          td {{ p.package.description }}
-          td.quality {{ Math.round(((p.score.detail.quality + p.score.detail.maintenance) / 2) * 100) }}
-          td.author
-            a(href='https://npmjs.com/~{{ p.package.publisher.username }}') {{ p.package.publisher.username }}
-          td
-            .links
-              if(condition='p.package.links.repository')
-                a.github(href='{{ p.package.links.repository }}') gh
-              else
-                span.github gh
-              if(condition='p.package.links.npm')
-                a.npm(href='{{ p.package.links.npm }}') npm
-              else
-                span.npm npm
+    .table-wrapper-fx
+      .table-wrapper
+        table
+          tr.header
+            th Name
+            th Description
+            th Quality
+            th Author
+            th Links
+          each(loop='p, i of plugins')
+            tr(class='p{{ i }}')
+              td.name
+                a(href='{{ p.package.links.repository || p.package.links.npm }}') {{ p.package.name }}
+              td {{ p.package.description }}
+              td.quality {{ Math.round(((p.score.detail.quality + p.score.detail.maintenance) / 2) * 100) }}
+              td.author
+                a(href='https://npmjs.com/~{{ p.package.publisher.username }}') {{ p.package.publisher.username }}
+              td
+                .links
+                  if(condition='p.package.links.repository')
+                    a.github(href='{{ p.package.links.repository }}') gh
+                  else
+                    span.github gh
+                  if(condition='p.package.links.npm')
+                    a.npm(href='{{ p.package.links.npm }}') npm
+                  else
+                    span.npm npm
 
     small(mdi) built with [spike](https://spike.cf)
 

--- a/views/layout.sgr
+++ b/views/layout.sgr
@@ -7,7 +7,7 @@ html
     meta(name='description' content='a directory for plugins')
     meta(name='author' content='Jeff Escalante')
     meta(name='viewport' content='width=device-width, initial-scale=1')
-    link(rel='stylesheet' href='https://fonts.googleapis.com/css?family=Roboto:400,500,700,300')
+    link(rel='stylesheet' href='https://fonts.googleapis.com/css?family=Roboto:300,400,500,700')
     title {{ title }}
     link(rel='stylesheet' href='css/index.css')
 


### PR DESCRIPTION
Preview result: https://reshape-plugins-preview.netlify.com

This pull request fixes following:

* not included font weight used in few places (100)
* unreadable thin fonts due to webkit antialiasing (switched from everything to bold & large)
* set up fallback github repo => npm link if github is undefined
* visual sugar: github/npm button is faded out if unavailable
* moved fixed `50px` padding to staggered max-width for table to be able to be ~100% on smaller screens
* added table wrapper to have table scrollable on lower resolutions
* add a little wrapper + javascript for visual sugar (shadows on table to show scrolled status)
* switched height on search button and fixed rounded corners on search field 

To be completely honest, on small screens, some sort of cards would be a better pattern for the plugins, but I didn't wanted to make such a big change.

AFAIK, most of this can/should be done in the spike plugins as well.